### PR TITLE
Add more ftdi wrappers

### DIFF
--- a/examples/dlp-loopback-tester.rs
+++ b/examples/dlp-loopback-tester.rs
@@ -6,7 +6,6 @@ extern crate ftdi;
 
 use std::io::{Read, Write};
 
-
 fn main() {
     println!("Starting tester...");
     let mut context = ftdi::Context::new();
@@ -50,9 +49,11 @@ fn main() {
             context.read_to_end(&mut reply).unwrap();
             let complement = 255 - num;
             if reply != vec![complement] {
-                println!("Wrong complement reply {:?} (expected {:?}",
-                         reply,
-                         vec![complement]);
+                println!(
+                    "Wrong complement reply {:?} (expected {:?}",
+                    reply,
+                    vec![complement]
+                );
             }
         }
         println!("Testing finished");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,16 @@ impl Context {
         }
     }
 
+    pub fn usb_close(&mut self) -> io::Result<()> {
+        let result = unsafe { ffi::ftdi_usb_close(&mut self.native) };
+        match result {
+            0 => Ok(()),
+            -1 => Err(io::Error::new(ErrorKind::Other, "usb release failed")),
+            -3 => Err(io::Error::new(ErrorKind::NotFound, "unknown ftdi context")),
+            _ => Err(io::Error::new(ErrorKind::Other, "unknown usb_open error")),
+        }
+    }
+
     pub fn set_latency_timer(&mut self, value: u8) -> io::Result<()> {
         let result = unsafe { ffi::ftdi_set_latency_timer(&mut self.native, value) };
         match result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,36 @@ impl Into<ffi::ftdi_interface> for Interface {
     }
 }
 
+pub enum BitMode {
+    RESET,
+    BITBANG,
+    MPSSE,
+    SYNCBB,
+    MCU,
+    OPTO,
+    CBUS,
+    SYNCFF,
+    FT1284,
+}
+
+impl Into<u8> for BitMode {
+    fn into(self) -> u8 {
+        let mode = match self {
+            BitMode::RESET => ffi::ftdi_mpsse_mode::BITMODE_RESET,
+            BitMode::BITBANG => ffi::ftdi_mpsse_mode::BITMODE_BITBANG,
+            BitMode::MPSSE => ffi::ftdi_mpsse_mode::BITMODE_MPSSE,
+            BitMode::SYNCBB => ffi::ftdi_mpsse_mode::BITMODE_SYNCBB,
+            BitMode::MCU => ffi::ftdi_mpsse_mode::BITMODE_MCU,
+            BitMode::OPTO => ffi::ftdi_mpsse_mode::BITMODE_OPTO,
+            BitMode::CBUS => ffi::ftdi_mpsse_mode::BITMODE_CBUS,
+            BitMode::SYNCFF => ffi::ftdi_mpsse_mode::BITMODE_SYNCFF,
+            BitMode::FT1284 => ffi::ftdi_mpsse_mode::BITMODE_FT1284,
+        };
+
+        mode as u8
+    }
+}
+
 #[allow(non_camel_case_types)]
 pub enum FlowControl {
     SIO_DISABLE_FLOW_CTRL,
@@ -196,6 +226,19 @@ impl Context {
             _ => Err(io::Error::new(
                 ErrorKind::Other,
                 "unknown set flow control error",
+            )),
+        }
+    }
+
+    pub fn set_bitmode(&mut self, bitmask: u8, mode: BitMode) -> io::Result<()> {
+        let result = unsafe { ffi::ftdi_set_bitmode(&mut self.native, bitmask, mode.into()) };
+        match result {
+            0 => Ok(()),
+            -1 => Err(io::Error::new(ErrorKind::Other, "set bitmode failed")),
+            -2 => Err(io::Error::new(ErrorKind::NotFound, "device not found")),
+            _ => Err(io::Error::new(
+                ErrorKind::Other,
+                "unknown set bitmode error",
             )),
         }
     }


### PR DESCRIPTION
This PR adds the following new Rust wrappers for libftdi functions:
- usb_close
- set_bitmode and BitMode enum
- set_flow_control and FlowControl enum

Besides, minor cleanup patch is queued: coding style by _rust fmt_.

Regards,
Sergey