### PR TITLE
Merge `ftdi-rs` and `safe-ftdi`- part 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Denis Lisov <dennis.lissov@gmail.com>"]
 name = "ftdi"
-version = "0.0.2"
+version = "0.1.0"
 keywords = ["hardware","ftdi", "libftdi1"]
 description = "A Rust wrapper over libftdi1 library for FTDI devices"
 license = "MIT"
@@ -9,5 +9,8 @@ homepage = "https://github.com/tanriol/ftdi-rs"
 repository = "https://github.com/tanriol/ftdi-rs"
 
 [dependencies]
-libftdi1-sys = "0.1.0"
+libftdi1-sys = { git = "https://github.com/tanriol/libftdi1-sys", version="1.0.0-alpha2", rev="804d9e8"}
 num = "0.1.30"
+
+[features]
+bindgen = ["libftdi1-sys/bindgen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/tanriol/ftdi-rs"
 
 [dependencies]
 libftdi1-sys = { git = "https://github.com/tanriol/libftdi1-sys", version="1.0.0-alpha2", rev="804d9e8"}
-num = "0.1.30"
 
 [features]
 bindgen = ["libftdi1-sys/bindgen"]

--- a/examples/dlp-loopback-tester.rs
+++ b/examples/dlp-loopback-tester.rs
@@ -9,7 +9,7 @@ use std::io::{Read, Write};
 
 fn main() {
     println!("Starting tester...");
-    let mut context = ftdi::Context::new();
+    let mut context = ftdi::Context::new().unwrap();
     context.set_interface(ftdi::Interface::A).unwrap();
 
     if context.usb_open(0x0403, 0x6010).is_ok() {

--- a/examples/dlp-loopback-tester.rs
+++ b/examples/dlp-loopback-tester.rs
@@ -6,7 +6,6 @@ extern crate ftdi;
 
 use std::io::{Read, Write};
 
-
 fn main() {
     println!("Starting tester...");
     let mut context = ftdi::Context::new().unwrap();
@@ -50,9 +49,11 @@ fn main() {
             context.read_to_end(&mut reply).unwrap();
             let complement = 255 - num;
             if reply != vec![complement] {
-                println!("Wrong complement reply {:?} (expected {:?}",
-                         reply,
-                         vec![complement]);
+                println!(
+                    "Wrong complement reply {:?} (expected {:?}",
+                    reply,
+                    vec![complement]
+                );
             }
         }
         println!("Testing finished");

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 use std::error;
 use std::fmt;
 use std::os::raw;
-use std::str;
 use std::result;
+use std::str;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use std::error;
+use std::fmt;
 
 #[derive(Debug)]
 pub enum Error {
@@ -9,27 +9,20 @@ pub enum Error {
 
 #[derive(Debug)]
 pub struct LibFtdiError {
-    err_str : &'static str,
+    err_str: &'static str,
 }
 
 impl LibFtdiError {
-    pub fn new(err_str : &'static str) -> LibFtdiError {
-        LibFtdiError {
-            err_str : err_str,
-        }
+    pub fn new(err_str: &'static str) -> LibFtdiError {
+        LibFtdiError { err_str }
     }
 }
-
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::LibFtdi(_) => {
-                write!(f, "libftdi-internal error")
-            },
-            Error::MallocFailure => {
-                write!(f, "malloc() failure")
-            }
+            Error::LibFtdi(_) => write!(f, "libftdi-internal error"),
+            Error::MallocFailure => write!(f, "malloc() failure"),
         }
     }
 }
@@ -43,12 +36,8 @@ impl fmt::Display for LibFtdiError {
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
-            Error::LibFtdi(ref ftdi_err) => {
-                Some(ftdi_err)
-            },
-            Error::MallocFailure => {
-                None
-            }
+            Error::LibFtdi(ref ftdi_err) => Some(ftdi_err),
+            Error::MallocFailure => None,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use std::ffi::CStr;
 use std::fmt;
 use std::os::raw;
 use std::str;
+use std::result;
 
 #[derive(Debug)]
 pub enum Error {
@@ -70,6 +71,8 @@ impl error::Error for Error {
     }
 }
 
+pub type Result<T> = result::Result<T, Error>;
+
 pub(super) struct LibFtdiReturn<'a>(raw::c_int, &'a super::Context);
 
 impl<'a> LibFtdiReturn<'a> {
@@ -78,8 +81,8 @@ impl<'a> LibFtdiReturn<'a> {
     }
 }
 
-impl<'a> Into<Result<u32, Error>> for LibFtdiReturn<'a> {
-    fn into(self) -> Result<u32, Error> {
+impl<'a> Into<Result<u32>> for LibFtdiReturn<'a> {
+    fn into(self) -> Result<u32> {
         match u32::try_from(self.0) {
             // In libftdi1, return codes >= 0 are success.
             Ok(v) => Ok(v),
@@ -99,8 +102,8 @@ impl<'a> Into<Result<u32, Error>> for LibFtdiReturn<'a> {
     }
 }
 
-impl<'a> Into<Result<(), Error>> for LibFtdiReturn<'a> {
-    fn into(self) -> Result<(), Error> {
+impl<'a> Into<Result<()>> for LibFtdiReturn<'a> {
+    fn into(self) -> Result<()> {
         match u32::try_from(self.0) {
             // In libftdi1, return codes >= 0 are success.
             Ok(_) => Ok(()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,12 +14,13 @@ pub enum Error {
 
 #[derive(Debug)]
 pub struct LibFtdiError {
+    code: raw::c_int,
     err_str: &'static str,
 }
 
 impl LibFtdiError {
-    pub fn new(err_str: &'static str) -> LibFtdiError {
-        LibFtdiError { err_str }
+    pub fn new(code: raw::c_int, err_str: &'static str) -> LibFtdiError {
+        LibFtdiError { code, err_str }
     }
 }
 
@@ -50,7 +51,7 @@ impl fmt::Display for Error {
 
 impl fmt::Display for LibFtdiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.err_str)
+        write!(f, "{} ({})", self.err_str, self.code)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,56 @@
+use std::fmt;
+use std::error;
+
+#[derive(Debug)]
+pub enum Error {
+    LibFtdi(LibFtdiError),
+    MallocFailure,
+}
+
+#[derive(Debug)]
+pub struct LibFtdiError {
+    err_str : &'static str,
+}
+
+impl LibFtdiError {
+    pub fn new(err_str : &'static str) -> LibFtdiError {
+        LibFtdiError {
+            err_str : err_str,
+        }
+    }
+}
+
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::LibFtdi(_) => {
+                write!(f, "libftdi-internal error")
+            },
+            Error::MallocFailure => {
+                write!(f, "malloc() failure")
+            }
+        }
+    }
+}
+
+impl fmt::Display for LibFtdiError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.err_str)
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            Error::LibFtdi(ref ftdi_err) => {
+                Some(ftdi_err)
+            },
+            Error::MallocFailure => {
+                None
+            }
+        }
+    }
+}
+
+impl std::error::Error for LibFtdiError {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,17 @@
+use std::convert::TryFrom;
 use std::error;
+use std::ffi::CStr;
 use std::fmt;
+use std::os::raw;
+use std::str::Utf8Error;
 
 #[derive(Debug)]
 pub enum Error {
     LibFtdi(LibFtdiError),
+    LibUsb(LibUsbError),
     MallocFailure,
+    UnexpectedErrorCode(raw::c_int),
+    Utf8(Utf8Error),
 }
 
 #[derive(Debug)]
@@ -18,11 +25,28 @@ impl LibFtdiError {
     }
 }
 
+#[derive(Debug)]
+pub struct LibUsbError {
+    err_str: &'static str,
+}
+
+// LibUsbError is a wrapper for the libusb-specific error types
+// returned by libftdi1, in case someone ever decides to implement
+// ftdi-rs directly over libusb.
+impl LibUsbError {
+    pub fn new(err_str: &'static str) -> LibUsbError {
+        LibUsbError { err_str }
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::LibFtdi(_) => write!(f, "libftdi-internal error"),
+            Error::LibUsb(_) => write!(f, "libusb-internal error"),
             Error::MallocFailure => write!(f, "malloc() failure"),
+            Error::UnexpectedErrorCode(c) => write!(f, "unknown libftdi error code {}", c),
+            Error::Utf8(_) => write!(f, "libftdi error string not UTF8"),
         }
     }
 }
@@ -33,13 +57,68 @@ impl fmt::Display for LibFtdiError {
     }
 }
 
+impl fmt::Display for LibUsbError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.err_str)
+    }
+}
+
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             Error::LibFtdi(ref ftdi_err) => Some(ftdi_err),
-            Error::MallocFailure => None,
+            _ => None,
+        }
+    }
+}
+
+pub(super) struct LibFtdiReturn<'a>(raw::c_int, &'a super::Context);
+
+impl<'a> LibFtdiReturn<'a> {
+    pub(super) fn new(rc: raw::c_int, ctx: &'a super::Context) -> Self {
+        LibFtdiReturn(rc, ctx)
+    }
+}
+
+impl<'a> Into<Result<u32, Error>> for LibFtdiReturn<'a> {
+    fn into(self) -> Result<u32, Error> {
+        match u32::try_from(self.0) {
+            // In libftdi1, return codes >= 0 are success.
+            Ok(v) => Ok(v),
+            Err(_) => match self.0 {
+                -13..=-1 | -666 => {
+                    let err_raw = unsafe { super::ffi::ftdi_get_error_string(self.1.native) };
+
+                    match unsafe { CStr::from_ptr(err_raw) }.to_str() {
+                        Ok(err_str) => Err(Error::LibFtdi(LibFtdiError { err_str })),
+                        Err(utf8_err) => Err(Error::Utf8(utf8_err)),
+                    }
+                }
+                unk => Err(Error::UnexpectedErrorCode(unk)),
+            },
+        }
+    }
+}
+
+impl<'a> Into<Result<(), Error>> for LibFtdiReturn<'a> {
+    fn into(self) -> Result<(), Error> {
+        match u32::try_from(self.0) {
+            // In libftdi1, return codes >= 0 are success.
+            Ok(_) => Ok(()),
+            Err(_) => match self.0 {
+                -13..=-1 | -666 => {
+                    let err_raw = unsafe { super::ffi::ftdi_get_error_string(self.1.native) };
+
+                    match unsafe { CStr::from_ptr(err_raw) }.to_str() {
+                        Ok(err_str) => Err(Error::LibFtdi(LibFtdiError { err_str })),
+                        Err(utf8_err) => Err(Error::Utf8(utf8_err)),
+                    }
+                }
+                unk => Err(Error::UnexpectedErrorCode(unk)),
+            },
         }
     }
 }
 
 impl std::error::Error for LibFtdiError {}
+impl std::error::Error for LibUsbError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use std::str;
 
 use libftdi1_sys as ffi;
 
-use std::io::{self, Read, Write, ErrorKind};
+use std::io::{self, ErrorKind, Read, Write};
 
 pub mod error;
 use error::{Error, LibFtdiError, Result};
@@ -100,7 +100,9 @@ impl Builder {
     pub fn usb_open(self, vendor: u16, product: u16) -> io::Result<Device> {
         let result = unsafe { ffi::ftdi_usb_open(self.context, vendor as i32, product as i32) };
         match result {
-            0 => Ok(Device { context: self.context }),
+            0 => Ok(Device {
+                context: self.context,
+            }),
             -3 => Err(io::Error::new(ErrorKind::NotFound, "device not found")),
             -4 => Err(io::Error::new(ErrorKind::Other, "unable to open device")),
             -5 => Err(io::Error::new(ErrorKind::Other, "unable to claim device")),
@@ -182,9 +184,7 @@ impl Device {
     }
 
     pub fn set_write_chunksize(&mut self, value: u32) {
-        let result = unsafe {
-            ffi::ftdi_write_data_set_chunksize(self.context, value)
-        };
+        let result = unsafe { ffi::ftdi_write_data_set_chunksize(self.context, value) };
         match result {
             0 => (),
             err => panic!("unknown set_write_chunksize retval {:?}", err),
@@ -193,9 +193,7 @@ impl Device {
 
     pub fn write_chunksize(&mut self) -> u32 {
         let mut value = 0;
-        let result = unsafe {
-            ffi::ftdi_write_data_get_chunksize(self.context, &mut value)
-        };
+        let result = unsafe { ffi::ftdi_write_data_get_chunksize(self.context, &mut value) };
         match result {
             0 => value,
             err => panic!("unknown get_write_chunksize retval {:?}", err),
@@ -203,9 +201,7 @@ impl Device {
     }
 
     pub fn set_read_chunksize(&mut self, value: u32) {
-        let result = unsafe {
-            ffi::ftdi_read_data_set_chunksize(self.context, value)
-        };
+        let result = unsafe { ffi::ftdi_read_data_set_chunksize(self.context, value) };
         match result {
             0 => (),
             err => panic!("unknown set_write_chunksize retval {:?}", err),
@@ -214,9 +210,7 @@ impl Device {
 
     pub fn read_chunksize(&mut self) -> u32 {
         let mut value = 0;
-        let result = unsafe {
-            ffi::ftdi_read_data_get_chunksize(self.context, &mut value)
-        };
+        let result = unsafe { ffi::ftdi_read_data_get_chunksize(self.context, &mut value) };
         match result {
             0 => value,
             err => panic!("unknown get_write_chunksize retval {:?}", err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 use std::convert::TryInto;
 use std::ffi::CStr;
+use std::num;
 use std::os::raw;
 use std::str;
 
@@ -148,13 +149,14 @@ impl Device {
         }
     }
 
-    pub fn set_latency_timer(&mut self, value: u8) -> Result<()> {
-        let result = unsafe { ffi::ftdi_set_latency_timer(self.context, value) };
+    pub fn set_latency_timer(&mut self, value: num::NonZeroU8) -> Result<()> {
+        let result = unsafe { ffi::ftdi_set_latency_timer(self.context, value.get()) };
 
         map_result(
             result,
             |e| match e {
-                -1 | -2 | -3 => Error::LibFtdi(LibFtdiError::new(e, error_string(self.context))),
+                -2 => Error::LibFtdi(LibFtdiError::new(e, error_string(self.context))),
+                -1 | -3 => unreachable!(),
                 unk => Error::UnexpectedErrorCode(unk),
             },
             |_| (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,10 @@ extern crate libftdi1_sys as ffi;
 use std::convert::TryInto;
 use std::io;
 use std::io::{ErrorKind, Read, Write};
-use std::result;
 use std::os::raw;
 
 pub mod error;
-use error::Error;
+use error::{Error, Result};
 
 /// The target interface
 pub enum Interface {
@@ -33,8 +32,6 @@ impl Into<ffi::ftdi_interface> for Interface {
         }
     }
 }
-
-pub type Result<T> = result::Result<T, error::Error>;
 
 pub struct Context {
     native: *mut ffi::ftdi_context,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,11 @@
 //!
 //! Note: the library interface is *definitely* unstable for now
 
-extern crate num;
-
 extern crate libftdi1_sys as ffi;
 
 use std::io;
 use std::io::{ErrorKind, Read, Write};
-
-use num::traits::ToPrimitive;
+use std::convert::TryInto;
 
 pub mod error;
 
@@ -177,7 +174,7 @@ impl Drop for Context {
 
 impl Read for Context {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let len = buf.len().to_i32().unwrap_or(std::i32::MAX);
+        let len = buf.len().try_into().unwrap_or(std::i32::MAX);
         let result = unsafe { ffi::ftdi_read_data(self.native, buf.as_mut_ptr(), len) };
         match result {
             count if count >= 0 => Ok(count as usize),
@@ -195,7 +192,7 @@ impl Read for Context {
 
 impl Write for Context {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let len = buf.len().to_i32().unwrap_or(std::i32::MAX);
+        let len = buf.len().try_into().unwrap_or(std::i32::MAX);
         let result = unsafe { ffi::ftdi_write_data(self.native, buf.as_ptr(), len) };
         match result {
             count if count >= 0 => Ok(count as usize),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,11 @@ extern crate num;
 extern crate libftdi1_sys as ffi;
 
 use std::io;
-use std::io::{Read, Write, ErrorKind};
+use std::io::{ErrorKind, Read, Write};
 
 use num::traits::ToPrimitive;
 
 pub mod error;
-use error::*;
-
 
 /// The target interface
 pub enum Interface {
@@ -36,7 +34,6 @@ impl Into<ffi::ftdi_interface> for Interface {
     }
 }
 
-
 pub struct Context {
     native: *mut ffi::ftdi_context,
 }
@@ -58,7 +55,10 @@ impl Context {
             -1 => Err(io::Error::new(ErrorKind::InvalidInput, "unknown interface")),
             -2 => Err(io::Error::new(ErrorKind::NotFound, "device not found")),
             -3 => Err(io::Error::new(ErrorKind::Other, "device already opened")),
-            _ => Err(io::Error::new(ErrorKind::Other, "unknown set latency error")),
+            _ => Err(io::Error::new(
+                ErrorKind::Other,
+                "unknown set latency error",
+            )),
         }
     }
 
@@ -73,8 +73,14 @@ impl Context {
             -7 => Err(io::Error::new(ErrorKind::Other, "set baudrate failed")),
             -8 => Err(io::Error::new(ErrorKind::Other, "get description failed")),
             -9 => Err(io::Error::new(ErrorKind::Other, "get serial failed")),
-            -12 => Err(io::Error::new(ErrorKind::Other, "libusb_get_device_list failed")),
-            -13 => Err(io::Error::new(ErrorKind::Other, "libusb_get_device_descriptor failed")),
+            -12 => Err(io::Error::new(
+                ErrorKind::Other,
+                "libusb_get_device_list failed",
+            )),
+            -13 => Err(io::Error::new(
+                ErrorKind::Other,
+                "libusb_get_device_descriptor failed",
+            )),
             _ => Err(io::Error::new(ErrorKind::Other, "unknown usb_open error")),
         }
     }
@@ -107,7 +113,10 @@ impl Context {
             -1 => Err(io::Error::new(ErrorKind::InvalidInput, "bad latency value")),
             -2 => Err(io::Error::new(ErrorKind::Other, "set latency failed")),
             -3 => Err(io::Error::new(ErrorKind::NotFound, "device not found")),
-            _ => Err(io::Error::new(ErrorKind::Other, "unknown set latency error")),
+            _ => Err(io::Error::new(
+                ErrorKind::Other,
+                "unknown set latency error",
+            )),
         }
     }
 
@@ -118,49 +127,44 @@ impl Context {
             0 => Ok(value),
             -1 => Err(io::Error::new(ErrorKind::Other, "set latency failed")),
             -2 => Err(io::Error::new(ErrorKind::NotFound, "device not found")),
-            _ => Err(io::Error::new(ErrorKind::Other, "unknown get latency error")),
+            _ => Err(io::Error::new(
+                ErrorKind::Other,
+                "unknown get latency error",
+            )),
         }
     }
 
     pub fn set_write_chunksize(&mut self, value: u32) {
-        let result = unsafe {
-            ffi::ftdi_write_data_set_chunksize(self.native, value)
-        };
+        let result = unsafe { ffi::ftdi_write_data_set_chunksize(self.native, value) };
         match result {
             0 => (),
-            err => panic!("unknown set_write_chunksize retval {:?}", err)
+            err => panic!("unknown set_write_chunksize retval {:?}", err),
         }
     }
 
     pub fn write_chunksize(&mut self) -> u32 {
         let mut value = 0;
-        let result = unsafe {
-            ffi::ftdi_write_data_get_chunksize(self.native, &mut value)
-        };
+        let result = unsafe { ffi::ftdi_write_data_get_chunksize(self.native, &mut value) };
         match result {
             0 => value,
-            err => panic!("unknown get_write_chunksize retval {:?}", err)
+            err => panic!("unknown get_write_chunksize retval {:?}", err),
         }
     }
 
     pub fn set_read_chunksize(&mut self, value: u32) {
-        let result = unsafe {
-            ffi::ftdi_read_data_set_chunksize(self.native, value)
-        };
+        let result = unsafe { ffi::ftdi_read_data_set_chunksize(self.native, value) };
         match result {
             0 => (),
-            err => panic!("unknown set_write_chunksize retval {:?}", err)
+            err => panic!("unknown set_write_chunksize retval {:?}", err),
         }
     }
 
     pub fn read_chunksize(&mut self) -> u32 {
         let mut value = 0;
-        let result = unsafe {
-            ffi::ftdi_read_data_get_chunksize(self.native, &mut value)
-        };
+        let result = unsafe { ffi::ftdi_read_data_get_chunksize(self.native, &mut value) };
         match result {
             0 => value,
-            err => panic!("unknown get_write_chunksize retval {:?}", err)
+            err => panic!("unknown get_write_chunksize retval {:?}", err),
         }
     }
 }
@@ -177,11 +181,14 @@ impl Read for Context {
         let result = unsafe { ffi::ftdi_read_data(self.native, buf.as_mut_ptr(), len) };
         match result {
             count if count >= 0 => Ok(count as usize),
-            -666 => Err(io::Error::new(ErrorKind::NotFound, "device not found in read")),
-            libusb_error => {
-                Err(io::Error::new(ErrorKind::Other,
-                                   format!("libusb_bulk_transfer error {}", libusb_error)))
-            }
+            -666 => Err(io::Error::new(
+                ErrorKind::NotFound,
+                "device not found in read",
+            )),
+            libusb_error => Err(io::Error::new(
+                ErrorKind::Other,
+                format!("libusb_bulk_transfer error {}", libusb_error),
+            )),
         }
     }
 }
@@ -192,11 +199,14 @@ impl Write for Context {
         let result = unsafe { ffi::ftdi_write_data(self.native, buf.as_ptr(), len) };
         match result {
             count if count >= 0 => Ok(count as usize),
-            -666 => Err(io::Error::new(ErrorKind::NotFound, "device not found in write")),
-            libusb_error => {
-                Err(io::Error::new(ErrorKind::Other,
-                                   format!("usb_bulk_write error {}", libusb_error)))
-            }
+            -666 => Err(io::Error::new(
+                ErrorKind::NotFound,
+                "device not found in write",
+            )),
+            libusb_error => Err(io::Error::new(
+                ErrorKind::Other,
+                format!("usb_bulk_write error {}", libusb_error),
+            )),
         }
     }
 
@@ -204,7 +214,6 @@ impl Write for Context {
         Ok(())
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,21 +35,21 @@ impl Into<ffi::ftdi_interface> for Interface {
 
 
 pub struct Context {
-    native: ffi::ftdi_context,
+    native: *mut ffi::ftdi_context,
 }
 
 impl Context {
     pub fn new() -> Context {
-        let mut context = Context { native: Default::default() };
-        let result = unsafe { ffi::ftdi_init(&mut context.native) };
+        let ctx = unsafe { ffi::ftdi_new() };
         // Can be non-zero on either OOM or libusb_init failure
-        assert!(result == 0);
-        context
+        assert!(!ctx.is_null());
+
+        Context { native: ctx }
     }
 
     /// Do not call after opening the USB device
     pub fn set_interface(&mut self, interface: Interface) -> io::Result<()> {
-        let result = unsafe { ffi::ftdi_set_interface(&mut self.native, interface.into()) };
+        let result = unsafe { ffi::ftdi_set_interface(self.native, interface.into()) };
         match result {
             0 => Ok(()),
             -1 => Err(io::Error::new(ErrorKind::InvalidInput, "unknown interface")),
@@ -60,7 +60,7 @@ impl Context {
     }
 
     pub fn usb_open(&mut self, vendor: u16, product: u16) -> io::Result<()> {
-        let result = unsafe { ffi::ftdi_usb_open(&mut self.native, vendor as i32, product as i32) };
+        let result = unsafe { ffi::ftdi_usb_open(self.native, vendor as i32, product as i32) };
         match result {
             0 => Ok(()),
             -3 => Err(io::Error::new(ErrorKind::NotFound, "device not found")),
@@ -77,7 +77,7 @@ impl Context {
     }
 
     pub fn usb_reset(&mut self) -> io::Result<()> {
-        let result = unsafe { ffi::ftdi_usb_reset(&mut self.native) };
+        let result = unsafe { ffi::ftdi_usb_reset(self.native) };
         match result {
             0 => Ok(()),
             -1 => Err(io::Error::new(ErrorKind::Other, "reset failed")),
@@ -87,7 +87,7 @@ impl Context {
     }
 
     pub fn usb_purge_buffers(&mut self) -> io::Result<()> {
-        let result = unsafe { ffi::ftdi_usb_purge_buffers(&mut self.native) };
+        let result = unsafe { ffi::ftdi_usb_purge_buffers(self.native) };
         match result {
             0 => Ok(()),
             -1 => Err(io::Error::new(ErrorKind::Other, "read purge failed")),
@@ -98,7 +98,7 @@ impl Context {
     }
 
     pub fn set_latency_timer(&mut self, value: u8) -> io::Result<()> {
-        let result = unsafe { ffi::ftdi_set_latency_timer(&mut self.native, value) };
+        let result = unsafe { ffi::ftdi_set_latency_timer(self.native, value) };
         match result {
             0 => Ok(()),
             -1 => Err(io::Error::new(ErrorKind::InvalidInput, "bad latency value")),
@@ -110,7 +110,7 @@ impl Context {
 
     pub fn latency_timer(&mut self) -> io::Result<u8> {
         let mut value = 0u8;
-        let result = unsafe { ffi::ftdi_get_latency_timer(&mut self.native, &mut value) };
+        let result = unsafe { ffi::ftdi_get_latency_timer(self.native, &mut value) };
         match result {
             0 => Ok(value),
             -1 => Err(io::Error::new(ErrorKind::Other, "set latency failed")),
@@ -121,7 +121,7 @@ impl Context {
 
     pub fn set_write_chunksize(&mut self, value: u32) {
         let result = unsafe {
-            ffi::ftdi_write_data_set_chunksize(&mut self.native, value)
+            ffi::ftdi_write_data_set_chunksize(self.native, value)
         };
         match result {
             0 => (),
@@ -132,7 +132,7 @@ impl Context {
     pub fn write_chunksize(&mut self) -> u32 {
         let mut value = 0;
         let result = unsafe {
-            ffi::ftdi_write_data_get_chunksize(&mut self.native, &mut value)
+            ffi::ftdi_write_data_get_chunksize(self.native, &mut value)
         };
         match result {
             0 => value,
@@ -142,7 +142,7 @@ impl Context {
 
     pub fn set_read_chunksize(&mut self, value: u32) {
         let result = unsafe {
-            ffi::ftdi_read_data_set_chunksize(&mut self.native, value)
+            ffi::ftdi_read_data_set_chunksize(self.native, value)
         };
         match result {
             0 => (),
@@ -153,7 +153,7 @@ impl Context {
     pub fn read_chunksize(&mut self) -> u32 {
         let mut value = 0;
         let result = unsafe {
-            ffi::ftdi_read_data_get_chunksize(&mut self.native, &mut value)
+            ffi::ftdi_read_data_get_chunksize(self.native, &mut value)
         };
         match result {
             0 => value,
@@ -164,14 +164,14 @@ impl Context {
 
 impl Drop for Context {
     fn drop(&mut self) {
-        unsafe { ffi::ftdi_deinit(&mut self.native) }
+        unsafe { ffi::ftdi_deinit(self.native) }
     }
 }
 
 impl Read for Context {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let len = buf.len().to_i32().unwrap_or(std::i32::MAX);
-        let result = unsafe { ffi::ftdi_read_data(&mut self.native, buf.as_mut_ptr(), len) };
+        let result = unsafe { ffi::ftdi_read_data(self.native, buf.as_mut_ptr(), len) };
         match result {
             count if count >= 0 => Ok(count as usize),
             -666 => Err(io::Error::new(ErrorKind::NotFound, "device not found in read")),
@@ -186,7 +186,7 @@ impl Read for Context {
 impl Write for Context {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let len = buf.len().to_i32().unwrap_or(std::i32::MAX);
-        let result = unsafe { ffi::ftdi_write_data(&mut self.native, buf.as_ptr(), len) };
+        let result = unsafe { ffi::ftdi_write_data(self.native, buf.as_ptr(), len) };
         match result {
             count if count >= 0 => Ok(count as usize),
             -666 => Err(io::Error::new(ErrorKind::NotFound, "device not found in write")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl Context {
                             str::from_utf8_unchecked(CStr::from_ptr(err_raw).to_bytes())
                         };
 
-                        Error::LibFtdi(LibFtdiError::new(err_str))
+                        Error::LibFtdi(LibFtdiError::new(res, err_str))
                     },
                 )
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ use std::io::{Read, Write, ErrorKind};
 
 use num::traits::ToPrimitive;
 
+pub mod error;
+use error::*;
+
 
 /// The target interface
 pub enum Interface {
@@ -39,12 +42,12 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new() -> Context {
+    pub fn new() -> Result<Context, ()> {
         let ctx = unsafe { ffi::ftdi_new() };
         // Can be non-zero on either OOM or libusb_init failure
         assert!(!ctx.is_null());
 
-        Context { native: ctx }
+        Ok(Context { native: ctx })
     }
 
     /// Do not call after opening the USB device


### PR DESCRIPTION
@tanriol This is quite an opinionated API design, especially wrt the `error::Error` type. Which is why this is a draft so you can yell at me for the bad parts :P. Right now, I've only gotten the error-handling portion worked out.

## `error::Error`
I've starting porting over the API functions you have created to use our own `error::Error` type. Each API function called in `libftdi1-sys`, and gets a `os::raw::c_int` as a return value. In `libftdi1`, I believe it is safe to assume that a positive integer or 0 is a success. Therefore, `try_into` on a `u32` can be used to distinguish success paths from failure paths.<sup>1</sup>

Because it's not possible to impl `Into`/`From` on foreign types, _and_ because I want to defer grabbing the ftdi error string until there's actually an error, I created a `LibFtdiReturn` "newtype" tuple struct. The tuple struct contains the `c_int` _and_ a reference to our `Context`, since grabbing an error string requires a pointer to its context.

### `Into<Result<T, error::Error>>`
I leveraged the `Into` trait<sup>2</sup> to convert the integer based error code from `libftdi1` into our own `error::Error` type. Each `ftdi-rs` function will look something like this:

```rust
pub type Result<T> = result::Result<T, error::Error>;

impl Context {
    fn mk_error(&self, res: raw::c_int) -> error::LibFtdiReturn {
            error::LibFtdiReturn::new(res, &self)
    }

    pub fn my_api(&mut self) -> Result<()> {
            let result = unsafe { ffi::ftdi_my_api(self.native) };

            self.mk_error(result).into()
    }
}
```

As far as I can tell, since we have to carry the `Context` around, this is the minimum amount of code one has to to write to port each API function. At the very least, the return type means the compiler can infer which `Into` implementation to call! If we didn't need the `Context`, I think we could implement `Into`/`From` directly on the newtype containing a `c_int`.

### Variants
* ` LibFtdi(LibFtdiError)`: Errors returned by `libftdi1` directly belong here. Contains an error string.
* `LibUsb(LibUsbError)`: I thought about separating out the errors that `libftdi1` reports come from `libusb1`, but unfortunately which error codes map to `libusb1` errors is on a per-API-function basis. Would appreciate feedback here.
* `MallocFailure`: If allocating a `Context` fails, report the failure in this variant.
* `UnexpectedErrorCode(c_int)`: I grepped for all the negative error codes returned by `libftdi1` and handle them all as part of converting from `LibFtdiReturn` to `Error`. Any negative codes that are recognized go here.
* `Utf8(Utf8Error)`: All `libftdi1` error strings are ASCII. However, there's no function- not even `unsafe`!- to convert a `CStr` to `&str` unchecked, so I store bad conversions here.

cc @yaahc, who gave me permission to tag her to look at this.

## Footnotes
1. There's probably some overflow issue when `c_int` isn't 32-bits- either 16 or 64 bits. But I don't think `libftdi1` runs on any system with a non 32-bit int.

2. Only in [1.40 and above](https://doc.rust-lang.org/std/convert/trait.Into.html#implementing-into-for-conversions-to-external-types-in-old-versions-of-rust) is a `From` impl possible here.