### PR TITLE
[WIP, RFC] device builder API

### DIFF
--- a/examples/dlp-loopback-tester.rs
+++ b/examples/dlp-loopback-tester.rs
@@ -9,10 +9,10 @@ use std::io::{Read, Write};
 
 fn main() {
     println!("Starting tester...");
-    let mut context = ftdi::Context::new();
-    context.set_interface(ftdi::Interface::A).unwrap();
+    let mut builder = ftdi::Builder::new();
+    builder.set_interface(ftdi::Interface::A).unwrap();
 
-    if context.usb_open(0x0403, 0x6010).is_ok() {
+    if let Ok(mut context) = builder.usb_open(0x0403, 0x6010) {
         println!("Device found and opened");
         context.usb_reset().unwrap();
         context.usb_purge_buffers().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,9 +199,3 @@ impl Write for Context {
     }
 }
 
-
-#[cfg(test)]
-mod test {
-    #[test]
-    fn it_works() {}
-}


### PR DESCRIPTION
Split `Context` into `Builder` (device not opened yet, can choose interface) and `Device` (interface chosen, device opened, can interact with it). This makes a number of API misuses, such as trying to change interface on the fly or send data before opening interface, impossible.