### PR TITLE
Add LibUsbError and InitFalied error variant. new returns Result. Bum…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftdi"
-version = "0.0.2"
+version = "0.1.0"
 authors = ["Denis Lisov <dennis.lissov@gmail.com>"]
 edition = "2018"
 
@@ -17,3 +17,6 @@ categories = ["api-bindings", "hardware-support"]
 [dependencies]
 libftdi1-sys = "1.0.0-alpha2"
 thiserror = "1.0.15"
+
+[features]
+bindgen = ["libftdi1-sys/bindgen"]

--- a/examples/dlp-loopback-tester.rs
+++ b/examples/dlp-loopback-tester.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 
 fn main() {
     println!("Starting tester...");
-    let mut builder = ftdi::Builder::new();
+    let mut builder = ftdi::Builder::new().unwrap();
     builder.set_interface(ftdi::Interface::A).unwrap();
 
     if let Ok(mut context) = builder.usb_open(0x0403, 0x6010) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,11 +2,14 @@ use thiserror::Error;
 
 use std::ffi::CStr;
 use std::io;
+use std::str;
 
 use super::ffi;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("failed to initialize the ftdi context")]
+    InitFailed,
     #[error("failed to enumerate devices to open the correct one")]
     EnumerationFailed,
     #[error("the specified device could not be found")]
@@ -34,9 +37,14 @@ pub enum Error {
 
 impl Error {
     pub(crate) fn unknown(context: *mut ffi::ftdi_context) -> Self {
-        let message = unsafe { CStr::from_ptr(ffi::ftdi_get_error_string(context)) }
-            .to_str()
-            .expect("all error strings are expected to be ASCII");
+        let message = unsafe {
+            // Null pointer returns empty string. And we otherwise can't
+            // use a context without Builder::new() returning first.
+            let err_raw = ffi::ftdi_get_error_string(context);
+            // Manually checked- every error string in libftdi1 is ASCII.
+            str::from_utf8_unchecked(CStr::from_ptr(err_raw).to_bytes())
+        };
+
         Error::Unknown {
             source: LibFtdiError { message },
         }
@@ -51,7 +59,13 @@ pub struct LibFtdiError {
     message: &'static str,
 }
 
+#[derive(Debug, Error)]
+#[error("libusb error code {code}")]
+pub struct LibUsbError {
+    code: i32,
+}
+
 // Ideally this should be using libusb bindings, but we don't depend on any specific USB crate yet
 pub(crate) fn libusb_to_io(code: i32) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, format!("libusb error code {}", code))
+    io::Error::new(io::ErrorKind::Other, LibUsbError { code })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,15 @@ pub struct Builder {
 }
 
 impl Builder {
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self> {
         let context = unsafe { ffi::ftdi_new() };
-        // Can be null on either OOM or libusb_init failure
-        assert!(!context.is_null());
 
-        Self { context }
+        // Can be non-zero on either OOM or libusb_init failure
+        if context.is_null() {
+            Err(Error::InitFailed)
+        } else {
+            Ok(Self { context })
+        }
     }
 
     pub fn set_interface(&mut self, interface: Interface) -> Result<()> {


### PR DESCRIPTION
…p version.

Rationale:

* As opposed to a string, `LibUsbError` has private fields which can change without breaking semver.
* Fallible construction is a reasonable API design. c.f. [`File::open`](https://doc.rust-lang.org/std/fs/struct.File.html#method.open). Add a variant to deal with that particular failure.
* Since all `libftdi1` strings are ASCII, converting to `UTF8` genuinely won't fail and I'd prefer not to panic in a library (though `unreachable!` already prevents that).
* `bindgen` feature is exposed- disabled by default.

