### PR TITLE
Make native ftdi_context public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ impl Into<ffi::ftdi_interface> for Interface {
 
 
 pub struct Context {
-    native: ffi::ftdi_context,
+    pub native: ffi::ftdi_context,
 }
 
 impl Context {


### PR DESCRIPTION
Hi, and thanks for the very useful bindings.

Here I'm suggesting making the native ftdi_context public, so that users of the library can more easily add their own temporary imperfect implementations of missing functions.

With this field private, I had to clone and modify the entire library rather than just adding one function in a custom trait. Making it public should save future users time in similar situations.

PR is proposed against the (untagged) actual 0.0.2 release as it would be useful right away and independently of future changes.

Many thanks again!