### PR TITLE
Add more ftdi wrappers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,9 @@ impl Device {
     }
 
     pub fn configure(&mut self, bits: Bits, stop_bits: StopBits, parity: Parity) -> Result<()> {
-        let result = unsafe { ffi::ftdi_set_line_property(self.context, bits.into(), stop_bits.into(), parity.into()) };
+        let result = unsafe {
+            ffi::ftdi_set_line_property(self.context, bits.into(), stop_bits.into(), parity.into())
+        };
         match result {
             0 => Ok(()),
             -1 => Err(Error::RequestFailed),


### PR DESCRIPTION
This PR adds the following new Rust wrappers for libftdi functions:

* usb_close
* set_bitmode and BitMode enum
* set_flow_control and FlowControl enum

This is an updated version of #2.

Regards,
Sergey