### PR TITLE
implement ftdi-mpsse traits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target
 Cargo.lock
+
+.idea
+.vscode
+rusty-tags.vi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ vendored = ["libftdi1-sys/vendored"]
 [dependencies]
 libftdi1-sys = "1.1"
 thiserror = "1.0.15"
+ftdi-mpsse = "0.1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,3 +57,7 @@ pub struct LibFtdiError {
 pub(crate) fn libusb_to_io(code: i32) -> io::Error {
     io::Error::new(io::ErrorKind::Other, format!("libusb error code {}", code))
 }
+
+pub(crate) fn libftdi_to_io(err: Error) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, err)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,36 @@ impl Device {
         }
     }
 
+    pub fn usb_set_event_char(&mut self, value: Option<u8>) -> Result<()> {
+        let result = if let Some(v) = value {
+            unsafe { ffi::ftdi_set_event_char(self.context, v, 1) }
+        } else {
+            unsafe { ffi::ftdi_set_event_char(self.context, 0, 0) }
+        };
+
+        match result {
+            0 => Ok(()),
+            -1 => Err(Error::RequestFailed),
+            -2 => unreachable!("uninitialized context"),
+            _ => Err(Error::unknown(self.context)),
+        }
+    }
+
+    pub fn usb_set_error_char(&mut self, value: Option<u8>) -> Result<()> {
+        let result = if let Some(v) = value {
+            unsafe { ffi::ftdi_set_error_char(self.context, v, 1) }
+        } else {
+            unsafe { ffi::ftdi_set_error_char(self.context, 0, 0) }
+        };
+
+        match result {
+            0 => Ok(()),
+            -1 => Err(Error::RequestFailed),
+            -2 => unreachable!("uninitialized context"),
+            _ => Err(Error::unknown(self.context)),
+        }
+    }
+
     pub fn set_latency_timer(&mut self, value: u8) -> Result<()> {
         let result = unsafe { ffi::ftdi_set_latency_timer(self.context, value) };
         match result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,13 @@
 //!
 //! Note: the library interface is *definitely* unstable for now
 
+use ftdi_mpsse::MpsseCmdBuilder;
+use ftdi_mpsse::MpsseCmdExecutor;
+use ftdi_mpsse::MpsseSettings;
+
 use libftdi1_sys as ffi;
 
+use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::io::{self, Read, Write};
 
@@ -15,6 +20,7 @@ pub use error::{Error, Result};
 pub use opener::find_by_raw_libusb_device;
 pub use opener::{find_by_bus_address, find_by_vid_pid, Opener};
 
+use error::libftdi_to_io;
 use error::libusb_to_io;
 
 /// The target interface
@@ -351,5 +357,100 @@ impl Write for Device {
 
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+impl Device {
+    pub fn set_mpsse_clock(&mut self, freq: u32) -> std::result::Result<(), io::Error> {
+        const MAX: u32 = 30_000_000;
+        const MIN: u32 = 92;
+
+        assert!(
+            freq >= MIN,
+            "frequency of {} exceeds minimum of {}",
+            freq,
+            MIN
+        );
+        assert!(
+            freq <= MAX,
+            "frequency of {} exceeds maximum of {}",
+            freq,
+            MAX
+        );
+
+        let (divisor, clkdiv) = if freq <= 6_000_000 {
+            (6_000_000 / freq - 1, Some(true))
+        } else {
+            (30_000_000 / freq - 1, Some(false))
+        };
+
+        self.write_all(MpsseCmdBuilder::new().set_clock(divisor, clkdiv).as_slice())?;
+
+        Ok(())
+    }
+}
+
+impl MpsseCmdExecutor for Device {
+    type Error = io::Error;
+
+    /// Initialize the MPSSE controller.
+    ///
+    /// According to AN135 [FTDI MPSSE basics], this method does the following:
+    /// 1. Optionally resets the peripheral side of FTDI port.
+    /// 2. Configures the maximum USB transfer sizes.
+    /// 3. Disables any event or error special characters.
+    /// 4. Configures the read and write timeouts (not yet implemented).
+    /// 5. Configures the latency timer to wait before sending an incomplete USB packet
+    ///    from the peripheral back to the host.
+    /// 6. Configures for RTS/CTS flow control to ensure that the driver will not issue
+    ///    IN requests if the buffer is unable to accept data.
+    /// 7. Resets and then enables the MPSSE controller
+    /// 8. Optionally configures the MPSSE clock frequency.
+    ///
+    /// [FTDI MPSSE Basics]: https://www.ftdichip.com/Support/Documents/AppNotes/AN_135_MPSSE_Basics.pdf
+    fn init(&mut self, settings: &MpsseSettings) -> std::result::Result<(), io::Error> {
+        let millis = u8::try_from(settings.latency_timer.as_millis())
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        if settings.reset {
+            self.usb_reset().map_err(libftdi_to_io)?;
+        }
+
+        self.usb_purge_buffers().map_err(libftdi_to_io)?;
+        self.set_write_chunksize(settings.in_transfer_size);
+        self.set_read_chunksize(settings.in_transfer_size);
+        self.set_latency_timer(millis).map_err(libftdi_to_io)?;
+        self.usb_set_event_char(None).map_err(libftdi_to_io)?;
+        self.usb_set_error_char(None).map_err(libftdi_to_io)?;
+        self.set_flow_control(FlowControl::RtsCts)
+            .map_err(libftdi_to_io)?;
+        self.set_bitmode(0, BitMode::Reset).map_err(libftdi_to_io)?;
+        self.set_bitmode(settings.mask, BitMode::Mpsse)
+            .map_err(libftdi_to_io)?;
+
+        if let Some(frequency) = settings.clock_frequency {
+            self.set_mpsse_clock(frequency)?;
+        }
+
+        Ok(())
+    }
+
+    /// Write the MPSSE command to the device.
+    ///
+    /// Workaround: perform Tx flush before sending data.
+    /// Otherwise several first readings from FTDI chip in the exchange sequence may be broken.
+    /// E.g. reading during the first exchange returns nothing, but reading during the second
+    /// exchange returns both the first and second replies. So far it is not clear how to get
+    /// rid of this workaround. Note that such a workaround is not needed when FTDI proprietary
+    /// libftd2xx library is used.
+    fn send(&mut self, data: &[u8]) -> std::result::Result<(), io::Error> {
+        self.usb_purge_tx_buffer()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        self.write_all(data)
+    }
+
+    /// Read the MPSSE response from the device.
+    fn recv(&mut self, data: &mut [u8]) -> std::result::Result<(), io::Error> {
+        self.read_exact(data)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub use error::{Error, Result};
 pub use opener::find_by_raw_libusb_device;
 pub use opener::{find_by_bus_address, find_by_vid_pid, Opener};
 
+use error::libusb_to_io;
+
 /// The target interface
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Interface {
@@ -331,7 +333,7 @@ impl Read for Device {
         match result {
             count if count >= 0 => Ok(count as usize),
             -666 => unreachable!("uninitialized context"),
-            err => Err(error::libusb_to_io(err)),
+            err => Err(libusb_to_io(err)),
         }
     }
 }
@@ -343,7 +345,7 @@ impl Write for Device {
         match result {
             count if count >= 0 => Ok(count as usize),
             -666 => unreachable!("uninitialized context"),
-            err => Err(error::libusb_to_io(err)),
+            err => Err(libusb_to_io(err)),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,16 @@ impl Device {
         }
     }
 
+    pub fn usb_purge_tx_buffer(&mut self) -> Result<()> {
+        let result = unsafe { ffi::ftdi_usb_purge_tx_buffer(self.context) };
+        match result {
+            0 => Ok(()),
+            -1 => Err(Error::RequestFailed),
+            -2 => unreachable!("uninitialized context"),
+            _ => Err(Error::unknown(self.context)),
+        }
+    }
+
     pub fn set_latency_timer(&mut self, value: u8) -> Result<()> {
         let result = unsafe { ffi::ftdi_set_latency_timer(self.context, value) };
         match result {


### PR DESCRIPTION
Hi @tanriol 

The [ftdi-mpsse](https://github.com/ftdi-rs/ftdi-mpsse) crate provides a basic common layer for the FTDI MPSSE capable devices. The idea is to have an intermediate layer between MPSSE users and FTDI low level libraries like `ftdi-rs` or `libftd2xx-rs`. This commit implements MpsseCmdExecutor trait for FTDI device handlers provided by `ftdi-rs`. As a result, it will be possible to use `ftdi-rs` as a backend for [ftdi-embedded-hal](https://github.com/ftdi-rs/ftdi-embedded-hal).

Regards,
Sergey