### PR TITLE
Add Device.read_pins

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,18 @@ impl Device {
         }
     }
 
+    /// Reads the current pin state.
+    pub fn read_pins(&mut self) -> Result<u8> {
+        let mut value = 0;
+        let code = unsafe { libftdi1_sys::ftdi_read_pins(self.context, &mut value) };
+        match code {
+            0 => Ok(value),
+            -1 => Err(Error::RequestFailed),
+            -2 => unreachable!("uninitialized context"),
+            _ => Err(Error::unknown(self.context)),
+        }
+    }
+
     pub fn libftdi_context(&mut self) -> *mut ffi::ftdi_context {
         self.context
     }


### PR DESCRIPTION
`Device.read_pins` wraps `ftdi_read_pins`, which is used to read the current pin state.  This is useful in various bitbang modes, particularly when bitbanging the CBUS pins on an FT232R where it is the only way to read them.